### PR TITLE
Main readme image not showing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <br>
-  <a href="https://earthsense-1.onrender.com/"><img src="https://raw.githubusercontent.com/alittlebroken.earthsense/main/public/images/splash.png" alt="EarthSense" width="200"></a>
+  <a href="https://earthsense-1.onrender.com/"><img src="https://raw.githubusercontent.com/alittlebroken/earthsense/main/public/images/splash.png" alt="EarthSense" width="200"></a>
   <br>
   EarthSense
   <br>


### PR DESCRIPTION
Due to a typo in the url for the main readme image it does not currently display.